### PR TITLE
Remove textit-prefix in abstract 102.

### DIFF
--- a/_posts/2017-10-18-kalweit17a.md
+++ b/_posts/2017-10-18-kalweit17a.md
@@ -1,14 +1,14 @@
 ---
 title: Uncertainty-driven Imagination for Continuous Deep Reinforcement Learning
 abstract: Continuous control of high-dimensional systems can be achieved by current
-  state-of-the-art reinforcement learning methods such as the \textitDeep Deterministic
+  state-of-the-art reinforcement learning methods such as the Deep Deterministic
   Policy Gradient algorithm, but needs a significant amount of data samples. For real-world
   systems, this can be an obstacle since excessive data collection can be expensive,
   tedious or lead to physical damage. The main incentive of this work is to keep the
-  advantages of model-free $Q$-learning while minimizing real-world interaction by
+  advantages of model-free Q-learning while minimizing real-world interaction by
   the employment of a dynamics model learned in parallel. To counteract adverse effects
   of imaginary rollouts with an inaccurate model, a notion of uncertainty is introduced,
-  to make use of artificial data only in cases of \textithigh uncertainty. We evaluate
+  to make use of artificial data only in cases of high uncertainty. We evaluate
   our approach on three simulated robot tasks and achieve faster learning by at least
   40 per cent in comparison to vanilla DDPG with multiple updates.
 layout: inproceedings


### PR DESCRIPTION
Remove textit-prefix before 'Deep' and 'high', also remove the '$' around 'Q'. I am the author of this paper.